### PR TITLE
Add file tools to src/tools/index.js

### DIFF
--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -1,5 +1,6 @@
-// src/tools/index.js
 import {loadMcpServers} from '../mcp/index.js';
+import { ensureDirSync } from "https://deno.land/std@0.218.0/fs/mod.ts";
+import { dirname } from "https://deno.land/std@0.218.0/path/mod.ts";
 
 const getCurrentTime = {
   name: 'getCurrentTime',
@@ -12,13 +13,79 @@ const getCurrentTime = {
   run: async () => {return new Date().toISOString()}
 }
 
+const write_file = {
+  name: 'write_file',
+  description: 'Write content into a file, auto mkdir -p',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' },
+      content: { type: 'string' }
+    },
+    required: ['path', 'content']
+  },
+  run: async ({ path, content }) => {
+    ensureDirSync(dirname(path));
+    await Deno.writeTextFile(path, content);
+    return `File written to ${path}`;
+  }
+}
+
+const append_to_file = {
+  name: 'append_to_file',
+  description: 'Append content to the end of a file, auto mkdir -p',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' },
+      content: { type: 'string' }
+    },
+    required: ['path', 'content']
+  },
+  run: async ({ path, content }) => {
+    ensureDirSync(dirname(path));
+    await Deno.writeTextFile(path, content, { append: true });
+    return `Content appended to ${path}`;
+  }
+}
+
+const insert_into_class = {
+  name: 'insert_into_class',
+  description: 'Insert content into a class definition in a header file',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' },
+      content: { type: 'string' },
+      class_name: { type: 'string' }
+    },
+    required: ['path', 'content']
+  },
+  run: async ({ path, content, class_name }) => {
+    const fileContent = await Deno.readTextFile(path);
+    const insertPosition = fileContent.indexOf('// INSERT HERE');
+    if (insertPosition === -1) {
+      throw new Error('Insert position not found in the file');
+    }
+    const newContent = fileContent.slice(0, insertPosition) + content + fileContent.slice(insertPosition);
+    await Deno.writeTextFile(path, newContent);
+    return `Content inserted into ${path}`;
+  }
+}
+
 export default {
-  getCurrentTime
+  getCurrentTime,
+  write_file,
+  append_to_file,
+  insert_into_class
 }
 
 export async function loadTools() {
   return {
     getCurrentTime,
+    write_file,
+    append_to_file,
+    insert_into_class,
     ...await loadMcpServers()
   };
 }


### PR DESCRIPTION
Add new functions to `src/tools/index.js` to support file operations and class content insertion.

- **write_file**: 
  - Add function to write content into a file with auto `mkdir -p`.
  - Ensure directory creation and write content to the specified path.
- **append_to_file**: 
  - Add function to append content to the end of a file with auto `mkdir -p`.
  - Ensure directory creation and append content to the specified path.
- **insert_into_class**: 
  - Add function to insert content into a class definition in a header file.
  - Locate the insert position using a special comment and insert the content.
- Update export default and loadTools functions to include the new functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/briancsparks/js-llm-cli/pull/1?shareId=ef2aead2-bca0-4b6f-90b1-a50b9d34dd92).